### PR TITLE
OO 3.* and uv

### DIFF
--- a/forbered_afskrivining_af_foraeldede_sagsomkostninger/framework.py
+++ b/forbered_afskrivining_af_foraeldede_sagsomkostninger/framework.py
@@ -53,7 +53,3 @@ def log_exception(orchestrator_connection: OrchestratorConnection) -> callable:
     def inner(type, value, traceback):  # pylint: disable=redefined-builtin, redefined-outer-name
         orchestrator_connection.log_error(f"Uncaught Exception:\nType: {type}\nValue: {value}\nTrace: {traceback}")
     return inner
-
-
-if __name__ == '__main__':
-    main()

--- a/forbered_afskrivining_af_foraeldede_sagsomkostninger/tests/test_emails.py
+++ b/forbered_afskrivining_af_foraeldede_sagsomkostninger/tests/test_emails.py
@@ -28,6 +28,3 @@ class IntegrationTestEmails(unittest.TestCase):
         attachment_bytes_list, kmd_emails = get_emails(orchestrator_connection=mock_open_rchestrator, graph_access=graph_access)
         self.assertIsNotNone(attachment_bytes_list)
         self.assertIsNotNone(kmd_emails)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/main.py
+++ b/main.py
@@ -9,9 +9,6 @@ import sys
 script_directory = os.path.dirname(os.path.realpath(__file__))
 os.chdir(script_directory)
 
-subprocess.run("python -m venv .venv", check=True)
-subprocess.run(r'.venv\Scripts\pip install .', check=True)
-
-command_args = [r".venv\Scripts\python", "-m", "forbered_afskrivining_af_foraeldede_sagsomkostninger"] + sys.argv[1:]
-
+subprocess.run("pip install --upgrade uv", check=True)
+command_args = ["uv", "run", "python", "-m", "robot_framework"] + sys.argv[1:]
 subprocess.run(command_args, check=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "forbered_afskrivining_af_foraeldede_sagsomkostninger"
-version = "1.0.2"
+version = "1.1.0"
 authors = [
   { name="ITK Development", email="itk-rpa@mkb.aarhus.dk" },
 ]
@@ -16,7 +16,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "OpenOrchestrator == 2.*",
+    "OpenOrchestrator == 3.*",
     "Pillow",
     "ITK-dev-shared-components >= 1.0.0",
     "openpyxl <= 3.1.2"


### PR DESCRIPTION
Bump OpenOrchestrator dependency to 3.* and switch main.py to the uv-based bootstrap.